### PR TITLE
[FIX] documentation : images must be preceded by a line break

### DIFF
--- a/account_move_line_reconcile_manual/readme/DESCRIPTION.rst
+++ b/account_move_line_reconcile_manual/readme/DESCRIPTION.rst
@@ -3,13 +3,16 @@ This module adds a wizard to reconcile manually selected journal items. If the s
 For the old-time Odoo users, the feature provided by this module is similar to the wizard that was provided in the **account** module up to Odoo 11.0. It was later replaced by the special reconciliation JS interface, which was working well, but was not as fast and convenient.
 
 Full reconciliation:
+
 .. figure:: ../static/description/sshot_full_rec.png
    :alt: Full reconciliation
 
 Choose between partial reconciliation and full reconciliation with a write-off:
+
 .. figure:: ../static/description/sshot_partial_rec.png
    :alt: Choose between partial reconciliation and full reconciliation with a write-off
 
 Reconcile with write-off:
+
 .. figure:: ../static/description/sshot_rec_writeoff.png
    :alt: Reconcile with write-off


### PR DESCRIPTION
Before : 

![image](https://user-images.githubusercontent.com/3407482/222907866-de112401-6b76-4aeb-9bce-85817f403ca1.png)


After : 

![image](https://user-images.githubusercontent.com/3407482/222907903-cd716f32-2645-4e40-8313-c2d97204aee4.png)
