### PR TITLE
[18][REF] account_move_line_reconcile_manual: Manage multiple currency reconciliation

### DIFF
--- a/account_move_line_reconcile_manual/tests/test_reconcile_manual.py
+++ b/account_move_line_reconcile_manual/tests/test_reconcile_manual.py
@@ -2,6 +2,9 @@
 # @author: Alexis de Lattre <alexis.delattre@akretion.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from datetime import timedelta
+
+from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
@@ -48,113 +51,111 @@ class TestReconcileManual(TransactionCase):
         )
         cls.foreign_curr.write({"active": True})
 
-    def _generate_debit_reconcile_move(self, amount, currency_amount=0.0):
-        reconcile_line_vals = {
-            "account_id": self.rec_account.id,
-            "partner_id": self.partner.id,
-            "debit": amount,
-        }
-        other_line_vals = {
-            "account_id": self.other_account.id,
-            "partner_id": self.partner.id,
-            "credit": amount,
-        }
-        if currency_amount:
-            reconcile_line_vals.update(
-                {
-                    "amount_currency": currency_amount,
-                    "currency_id": self.foreign_curr.id,
-                }
-            )
-            other_line_vals.update(
-                {
-                    "amount_currency": -currency_amount,
-                    "currency_id": self.foreign_curr.id,
-                }
-            )
-
-        move = self.env["account.move"].create(
+        cls.three_days_ago = fields.Date.today() - timedelta(days=3)
+        cls.env["res.currency.rate"].create(
             {
-                "journal_id": self.journal.id,
-                "company_id": self.company.id,
-                "currency_id": not currency_amount
-                and self.ccur.id
-                or self.foreign_curr.id,
-                "line_ids": [
-                    (
-                        0,
-                        0,
-                        reconcile_line_vals,
-                    ),
-                    (
-                        0,
-                        0,
-                        other_line_vals,
-                    ),
-                ],
+                "currency_id": cls.foreign_curr.id,
+                "rate": 0.8,
+                "name": cls.three_days_ago,
+                "company_id": cls.company.id,
             }
         )
-        move._post(soft=False)
-        return move
-
-    def _generate_credit_reconcile_move(self, amount, currency_amount=0.0):
-        reconcile_line_vals = {
-            "account_id": self.rec_account.id,
-            "partner_id": self.partner.id,
-            "credit": amount,
-        }
-        other_line_vals = {
-            "account_id": self.other_account.id,
-            "partner_id": self.partner.id,
-            "debit": amount,
-        }
-        if currency_amount:
-            reconcile_line_vals.update(
-                {
-                    "amount_currency": -currency_amount,
-                    "currency_id": self.foreign_curr.id,
-                }
-            )
-            other_line_vals.update(
-                {
-                    "amount_currency": currency_amount,
-                    "currency_id": self.foreign_curr.id,
-                }
-            )
-
-        move = self.env["account.move"].create(
+        cls.two_days_ago = fields.Date.today() - timedelta(days=2)
+        cls.env["res.currency.rate"].create(
             {
-                "journal_id": self.journal.id,
-                "company_id": self.company.id,
-                "currency_id": not currency_amount
-                and self.ccur.id
-                or self.foreign_curr.id,
-                "line_ids": [
-                    (
-                        0,
-                        0,
-                        reconcile_line_vals,
-                    ),
-                    (
-                        0,
-                        0,
-                        other_line_vals,
-                    ),
-                ],
+                "currency_id": cls.foreign_curr.id,
+                "rate": 0.95,
+                "name": cls.two_days_ago,
+                "company_id": cls.company.id,
             }
         )
-        move._post(soft=False)
-        return move
+        cls.one_day_ago = fields.Date.today() - timedelta(days=1)
+        cls.env["res.currency.rate"].create(
+            {
+                "currency_id": cls.foreign_curr.id,
+                "rate": 1.1,
+                "name": cls.one_day_ago,
+                "company_id": cls.company.id,
+            }
+        )
+
+    def _create_rec_line(
+        self, amount, currency=None, company_amount=None, move_date=None, side="debit"
+    ):
+        is_debit = side == "debit"
+        date_move = move_date or fields.Date.today()
+
+        rec_line_vals = {
+            "name": f"Test {side}",
+            "account_id": self.rec_account.id,
+            "partner_id": self.partner.id,
+        }
+
+        if currency:
+            rec_line_vals.update(
+                {
+                    "currency_id": currency.id,
+                    "amount_currency": amount if is_debit else -amount,
+                }
+            )
+            if company_amount is not None:
+                # only if we force the rate, could be the case on payment where rate
+                # comes from the bank for instance
+                rec_line_vals.update(
+                    {
+                        "debit": company_amount if is_debit else 0.0,
+                        "credit": 0.0 if is_debit else company_amount,
+                    }
+                )
+        else:
+            rec_line_vals.update(
+                {
+                    "debit": amount if is_debit else 0.0,
+                    "credit": 0.0 if is_debit else amount,
+                }
+            )
+
+        move = (
+            self.env["account.move"]
+            .with_context(check_move_validity=False)
+            .create(
+                {
+                    "journal_id": self.journal.id,
+                    "date": date_move,
+                    "move_type": "entry",
+                    "line_ids": [(0, 0, rec_line_vals)],
+                }
+            )
+        )
+
+        main_line = move.line_ids[0]
+
+        self.env["account.move.line"].with_context(check_move_validity=False).create(
+            {
+                "move_id": move.id,
+                "name": "Contrepartie",
+                "account_id": self.other_account.id,
+                "partner_id": self.partner.id,
+                "debit": main_line.credit,
+                "credit": main_line.debit,
+                "currency_id": main_line.currency_id.id,
+                "amount_currency": -main_line.amount_currency,
+            }
+        )
+        move.action_post()
+        return main_line
+
+    def _assert_full_reconciled(self, lines, description):
+        self.assertTrue(all(li.reconciled for li in lines), description)
+        self.assertEqual(len(lines.full_reconcile_id), 1, description)
+        self.assertTrue(all(li.full_reconcile_id for li in lines), description)
+        for line in lines:
+            self.assertEqual(line.amount_residual, 0.0, description)
+            self.assertEqual(line.amount_residual_currency, 0.0, description)
 
     def test_reconcile_manual(self):
-        self.move1 = self._generate_debit_reconcile_move(100)
-        self.line1 = self.move1.line_ids.filtered(
-            lambda x: x.account_id == self.rec_account
-        )
-        self.move2 = self._generate_credit_reconcile_move(95)
-        self.line2 = self.move2.line_ids.filtered(
-            lambda x: x.account_id == self.rec_account
-        )
+        self.line1 = self._create_rec_line(100, side="debit")
+        self.line2 = self._create_rec_line(95, side="credit")
         # start with partial reconcile
         lines_to_rec = self.line1 + self.line2
         wiz1 = (
@@ -185,7 +186,7 @@ class TestReconcileManual(TransactionCase):
         self.assertEqual(wiz2.writeoff_type, "expense")
         wiz2.go_to_writeoff()
         self.assertEqual(wiz2.state, "writeoff")
-        self.assertFalse(self.ccur.compare_amounts(wiz2.writeoff_amount, 5))
+        self.assertFalse(self.ccur.compare_amounts(wiz2.writeoff_amount, -5))
         wiz2.write(
             {
                 "writeoff_journal_id": self.journal.id,
@@ -233,13 +234,11 @@ class TestReconcileManual(TransactionCase):
         self.assertEqual(self.line2.full_reconcile_id, full_rec4)
 
     def test_foreign_currency_full_reconcile(self):
-        self.move1 = self._generate_debit_reconcile_move(100, currency_amount=95)
-        self.line1 = self.move1.line_ids.filtered(
-            lambda x: x.account_id == self.rec_account
+        self.line1 = self._create_rec_line(
+            95, currency=self.foreign_curr, company_amount=100, side="debit"
         )
-        self.move2 = self._generate_credit_reconcile_move(101, currency_amount=95)
-        self.line2 = self.move2.line_ids.filtered(
-            lambda x: x.account_id == self.rec_account
+        self.line2 = self._create_rec_line(
+            95, currency=self.foreign_curr, company_amount=101, side="credit"
         )
         lines_to_rec = self.line1 + self.line2
         wiz = (
@@ -254,71 +253,155 @@ class TestReconcileManual(TransactionCase):
         self.assertFalse(self.foreign_curr.compare_amounts(wiz.total_credit, 95))
         self.assertEqual(wiz.writeoff_type, "none")
         wiz.full_reconcile()
-
-        self.assertTrue(self.line1.full_reconcile_id)
-        self.assertEqual(self.line1.full_reconcile_id, self.line2.full_reconcile_id)
-        self.assertTrue(self.line1.reconciled)
-        self.assertTrue(self.line2.reconciled)
-        self.assertFalse(self.line1.amount_residual_currency)
-        self.assertFalse(self.line1.amount_residual)
+        self._assert_full_reconciled(
+            lines_to_rec, "test_foreign_currency_full_reconcile"
+        )
         self.assertEqual(len(self.line1.full_reconcile_id.reconciled_line_ids), 3)
 
-    def test_foreign_currency_reconcile_with_write_off(self):
-        self.move1 = self._generate_debit_reconcile_move(100, currency_amount=95)
-        self.line1 = self.move1.line_ids.filtered(
-            lambda x: x.account_id == self.rec_account
-        )
-        self.move2 = self._generate_credit_reconcile_move(98, currency_amount=94)
-        self.line2 = self.move2.line_ids.filtered(
-            lambda x: x.account_id == self.rec_account
-        )
-        lines_to_rec = self.line1 + self.line2
-        wiz = (
-            self.env["account.move.line.reconcile.manual"]
-            .with_context(active_model="account.move.line", active_ids=lines_to_rec.ids)
-            .create({})
-        )
-        self.assertEqual(wiz.account_id, self.rec_account)
-        self.assertEqual(wiz.count, 2)
-        self.assertEqual(wiz.writeoff_type, "expense")
-        self.assertEqual(wiz.writeoff_amount, 1)
-        wiz.go_to_writeoff()
-        wiz.write(
-            {
-                "writeoff_journal_id": self.journal.id,
-                "writeoff_ref": self.writeoff_ref,
-                "writeoff_account_id": self.writeoff_account.id,
-            }
-        )
-        wiz.reconcile_with_writeoff()
+    def _test_full_reconcile_scenarios(self, scenarios):
+        for scenario, vals_list in scenarios.items():
+            lines_to_rec = self.env["account.move.line"]
+            for vals in vals_list:
+                lines_to_rec |= self._create_rec_line(
+                    vals["amount"],
+                    currency=vals.get("currency"),
+                    company_amount=vals.get("company_amount"),
+                    move_date=vals.get("move_date"),
+                    side=vals.get("side"),
+                )
+            wiz = (
+                self.env["account.move.line.reconcile.manual"]
+                .with_context(
+                    active_model="account.move.line", active_ids=lines_to_rec.ids
+                )
+                .create({})
+            )
+            if wiz.writeoff_type == "none":
+                wiz.full_reconcile()
+            else:
+                wiz.go_to_writeoff()
+                wiz.write(
+                    {
+                        "writeoff_journal_id": self.journal.id,
+                        "writeoff_ref": self.writeoff_ref,
+                        "writeoff_account_id": self.writeoff_account.id,
+                    }
+                )
+                wiz.reconcile_with_writeoff()
+            self._assert_full_reconciled(lines_to_rec, scenario)
 
-        self.assertTrue(self.line1.full_reconcile_id)
-        self.assertEqual(self.line1.full_reconcile_id, self.line2.full_reconcile_id)
-        self.assertTrue(self.line1.reconciled)
-        self.assertTrue(self.line2.reconciled)
+    def test_foreign_currency_reconcile_with_write_off(self):
+        scenarios = {
+            "1 - Dual Debit Residual (FC & CC)": [
+                {
+                    "side": "debit",
+                    "currency": self.foreign_curr,
+                    "amount": 95,
+                    "company_amount": 100,
+                },
+                {
+                    "side": "credit",
+                    "currency": self.foreign_curr,
+                    "amount": 94,
+                    "company_amount": 98,
+                },
+            ],
+            "2 - Mixed Residuals: Debit FC / Credit CC": [
+                {
+                    "side": "debit",
+                    "currency": self.foreign_curr,
+                    "amount": 95,
+                    "company_amount": 100,
+                },
+                {
+                    "side": "credit",
+                    "currency": self.foreign_curr,
+                    "amount": 94,
+                    "company_amount": 102,
+                },
+            ],
+            "3 - Mixed Residuals: Debit FC / Credit CC - 4 lines": [
+                {
+                    "side": "debit",
+                    "currency": self.foreign_curr,
+                    "amount": 95,
+                    "company_amount": 100,
+                },
+                {
+                    "side": "debit",
+                    "currency": self.foreign_curr,
+                    "amount": 95,
+                    "company_amount": 150,
+                },
+                {
+                    "side": "credit",
+                    "currency": self.foreign_curr,
+                    "amount": 95,
+                    "company_amount": 90,
+                },
+                {
+                    "side": "credit",
+                    "currency": self.foreign_curr,
+                    "amount": 94,
+                    "company_amount": 170,
+                },
+            ],
+            "4 - No CC residual": [
+                {
+                    "side": "debit",
+                    "currency": self.foreign_curr,
+                    "amount": 95,
+                    "company_amount": 100,
+                },
+                {
+                    "side": "credit",
+                    "currency": self.foreign_curr,
+                    "amount": 94,
+                    "company_amount": 100,
+                },
+            ],
+        }
+        self._test_full_reconcile_scenarios(scenarios)
 
     def test_multi_currency_full_reconcile(self):
-        self.move1 = self._generate_debit_reconcile_move(65.41, currency_amount=100)
-        self.line1 = self.move1.line_ids.filtered(
-            lambda x: x.account_id == self.rec_account
-        )
-        self.move2 = self._generate_credit_reconcile_move(30)
-        self.line2 = self.move2.line_ids.filtered(
-            lambda x: x.account_id == self.rec_account
-        )
-        lines_to_rec = self.line1 + self.line2
-        wiz = (
-            self.env["account.move.line.reconcile.manual"]
-            .with_context(active_model="account.move.line", active_ids=lines_to_rec.ids)
-            .create({})
-        )
-        self.assertEqual(wiz.writeoff_type, "expense")
-        wiz.go_to_writeoff()
-        wiz.write(
-            {
-                "writeoff_journal_id": self.journal.id,
-                "writeoff_ref": self.writeoff_ref,
-                "writeoff_account_id": self.writeoff_account.id,
-            }
-        )
-        wiz.reconcile_with_writeoff()
+        scenarios = {
+            "1 - Credit Residual CC": [
+                {
+                    "side": "debit",
+                    "currency": self.foreign_curr,
+                    "amount": 100,
+                    "company_amount": 65.41,
+                    "move_date": self.two_days_ago,
+                },
+                {"side": "credit", "amount": 30, "move_date": self.two_days_ago},
+            ],
+            "2 - debit Residual FC": [
+                {
+                    "side": "debit",
+                    "currency": self.foreign_curr,
+                    "amount": 100,
+                    "company_amount": 65.41,
+                    "move_date": self.three_days_ago,
+                },
+                {"side": "credit", "amount": 90, "move_date": self.two_days_ago},
+            ],
+            "3 - No CC residual": [
+                {
+                    "side": "credit",
+                    "currency": self.foreign_curr,
+                    "amount": 100,
+                    "company_amount": 65.41,
+                    "move_date": self.three_days_ago,
+                },
+                {
+                    "side": "credit",
+                    "currency": self.foreign_curr,
+                    "amount": 100,
+                    "company_amount": 80.41,
+                    "move_date": self.two_days_ago,
+                },
+                {"side": "debit", "amount": 60, "move_date": self.two_days_ago},
+                {"side": "debit", "amount": 85.82, "move_date": self.one_day_ago},
+            ],
+        }
+        self._test_full_reconcile_scenarios(scenarios)

--- a/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual.py
+++ b/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual.py
@@ -20,6 +20,9 @@ class AccountMoveLineReconcileManual(models.TransientModel):
     )
     company_id = fields.Many2one("res.company", required=True, readonly=True)
     currency_id = fields.Many2one("res.currency")
+    company_currency_id = fields.Many2one(
+        "res.currency", related="company_id.currency_id"
+    )
     count = fields.Integer(string="# of Journal Items", readonly=True)
     total_debit = fields.Monetary(currency_field="currency_id", readonly=True)
     total_credit = fields.Monetary(currency_field="currency_id", readonly=True)
@@ -37,6 +40,7 @@ class AccountMoveLineReconcileManual(models.TransientModel):
         default="start",
     )
     # START WRITE-OFF FIELDS
+    writeoff_currency_id = fields.Many2one("res.currency")
     writeoff_model_id = fields.Many2one(
         "account.reconcile.manual.model",
         string="Model",
@@ -72,7 +76,10 @@ class AccountMoveLineReconcileManual(models.TransientModel):
         string="Type",
     )
     writeoff_amount = fields.Monetary(
-        currency_field="currency_id", readonly=True, string="Amount"
+        currency_field="company_currency_id", readonly=True, string="Amount"
+    )
+    writeoff_amount_currency = fields.Monetary(
+        currency_field="writeoff_currency_id", readonly=True, string="Amount Currency"
     )
     writeoff_account_id = fields.Many2one(
         "account.account",
@@ -96,6 +103,7 @@ class AccountMoveLineReconcileManual(models.TransientModel):
             "Percentage Analytic"
         ),
     )
+    is_multi_currency = fields.Boolean()
 
     @api.depends("writeoff_model_id")
     def _compute_writeoff(self):
@@ -201,7 +209,6 @@ class AccountMoveLineReconcileManual(models.TransientModel):
             raise UserError(_("You selected only credit journal items."))
         if currency.is_zero(total_credit):
             raise UserError(_("You selected only debit journal items."))
-        writeoff_amount = currency.round(abs(total_debit - total_credit))
         total_debit = currency.round(total_debit)
         total_credit = currency.round(total_credit)
         compare_res = currency.compare_amounts(total_debit, total_credit)
@@ -222,8 +229,8 @@ class AccountMoveLineReconcileManual(models.TransientModel):
                 "partner_count": len(partner_set),
                 "partner_id": len(partner_set) == 1 and partner_set.pop() or False,
                 "move_line_ids": move_lines.ids,
+                "is_multi_currency": len(currencies) > 1,
                 "writeoff_type": writeoff_type,
-                "writeoff_amount": writeoff_amount,
             }
         )
         return res
@@ -256,8 +263,99 @@ class AccountMoveLineReconcileManual(models.TransientModel):
         self.move_line_ids.reconcile()
         return
 
+    def _get_writeoff_vals_by_simulation(self):
+        """
+        In some multi-currency reconciliation case, it is too complicated to 'guess'
+        the needed writeoff amounts. For these case, we do simulate the reconciliation
+        too get the real writeoff amounts
+        """
+        amls = self.move_line_ids
+        # From _reconcile_plan_with_sync
+        plan_list, all_amls = self.env[
+            "account.move.line"
+        ]._optimize_reconciliation_plan([amls])
+        aml_values_map = {
+            aml: {
+                "aml": aml,
+                "amount_residual": aml.amount_residual,
+                "amount_residual_currency": aml.amount_residual_currency,
+            }
+            for aml in all_amls
+        }
+        plan = plan_list[0]
+        # Simulate the reconciliation
+        # disable exchange difference because the writeoff will take care of it
+        # anyway.
+        self.env["account.move.line"].with_context(
+            no_exchange_difference=True
+        )._prepare_reconciliation_plan(plan, aml_values_map)
+
+        # aml_values_map is updated by the simulation, check residuals in order to
+        # compute the writeoff amounts we need to complete the reconciliation
+
+        residual_lines = self.env["account.move.line"]
+        residual = residual_currency = 0.0
+        currency = False
+        writeoff = True
+        for aml, vals in aml_values_map.items():
+            if vals["amount_residual"] or vals["amount_residual_currency"]:
+                residual_lines |= aml
+                residual += vals["amount_residual"]
+                residual_currency += vals["amount_residual_currency"]
+                if not currency:
+                    currency = aml.currency_id
+                if currency != aml.currency_id:
+                    writeoff = False
+                    break
+        if not writeoff:
+            return False
+        return {
+            "writeoff_amount": -residual,
+            "writeoff_amount_currency": -residual_currency,
+            "writeoff_currency_id": currency.id,
+        }
+
+    def _compute_writeoff_amounts(self):
+        # avoid redoing simulation if we do have the amounts already
+        if self.writeoff_amount or self.writeoff_amount_currency:
+            return
+        if self.is_multi_currency:
+            vals = self._get_writeoff_vals_by_simulation()
+            if vals:
+                self.write(vals)
+            else:
+                raise UserError(
+                    self.env._(
+                        "Can't compute the writeoff amount, it may be caused by too "
+                        "much currencies to be reconciled together. Yoy should probably"
+                        " do a partial reconciliation and create the required write-off"
+                        " entries manually to fully reconcile the remaining "
+                        "unreconciled entries."
+                    )
+                )
+
+        else:
+            writeoff_amount = self.currency_id.round(
+                -(self.total_debit - self.total_credit)
+            )
+            if self.currency_id != self.company_currency_id:
+                self.write(
+                    {
+                        "writeoff_amount_currency": writeoff_amount,
+                        "writeoff_currency_id": self.currency_id.id,
+                    }
+                )
+            else:
+                self.write(
+                    {
+                        "writeoff_amount": writeoff_amount,
+                        "writeoff_currency_id": self.currency_id.id,
+                    }
+                )
+
     def go_to_writeoff(self):
         self.ensure_one()
+        self._compute_writeoff_amounts()
         self.write({"state": "writeoff"})
         action = self.env["ir.actions.actions"]._for_xml_id(
             "account_move_line_reconcile_manual.account_move_line_reconcile_manual_action"
@@ -266,18 +364,21 @@ class AccountMoveLineReconcileManual(models.TransientModel):
         return action
 
     def _prepare_writeoff_move(self):
-        cur = self.currency_id
-        is_foreign_currency = self.company_id.currency_id != self.currency_id
+        # TODO manage case with not computed ccur amount
+        # Manage case of + currency and - euro ?
+        # could strategy be : partial reconcile
+        # reconcile resildual with write off by currency ?
+        cur = self.writeoff_currency_id
+        is_foreign_currency = self.company_currency_id != self.writeoff_currency_id
 
-        bal = cur.round(self.total_debit - self.total_credit)
+        bal_cur = cur.round(self.writeoff_amount_currency)
+        bal = self.company_id.currency_id.round(self.writeoff_amount)
         compare_res = cur.compare_amounts(bal, 0)
-        assert compare_res
+        debit = credit = 0.0
         if compare_res > 0:
-            credit = bal
-            debit = 0
+            debit = bal
         else:
-            debit = bal * -1
-            credit = 0
+            credit = bal * -1
         payment_term_line_vals = {
             "display_type": "payment_term",
             "account_id": self.account_id.id,
@@ -293,17 +394,32 @@ class AccountMoveLineReconcileManual(models.TransientModel):
         if is_foreign_currency:
             payment_term_line_vals.update(
                 {
-                    "currency_id": self.currency_id.id,
-                    "amount_currency": debit - credit,
+                    "currency_id": cur.id,
+                    "amount_currency": bal_cur,
                 }
             )
             product_line_vals.update(
                 {
-                    "currency_id": self.currency_id.id,
-                    "amount_currency": credit - debit,
+                    "currency_id": cur.id,
+                    "amount_currency": -bal_cur,
                 }
             )
-
+            # in multi currency mode, we simulate the reconciliation and we know
+            # both currency and company currency amounts while in normal case (mono
+            # currency reconciliation) we leave Odoo generates the exchange rate entries
+            if self.is_multi_currency:
+                payment_term_line_vals.update(
+                    {
+                        "debit": debit,
+                        "credit": credit,
+                    }
+                )
+                product_line_vals.update(
+                    {
+                        "debit": credit,
+                        "credit": debit,
+                    }
+                )
         else:
             payment_term_line_vals.update({"debit": debit, "credit": credit})
             product_line_vals.update(
@@ -332,7 +448,7 @@ class AccountMoveLineReconcileManual(models.TransientModel):
             ],
         }
         if is_foreign_currency:
-            vals["currency_id"] = self.currency_id.id
+            vals["currency_id"] = cur.id
         return vals
 
     def reconcile_with_writeoff(self):
@@ -348,11 +464,10 @@ class AccountMoveLineReconcileManual(models.TransientModel):
             lambda x: x.account_id.id == self.account_id.id
         )
         assert len(to_rec_woff_line) == 1
-        to_rec_lines = self.move_line_ids + to_rec_woff_line
         no_exchange_difference = len(self.move_line_ids.currency_id) > 1 or False
-        to_rec_lines.with_context(
+        self.env["account.move.line"].with_context(
             no_exchange_difference=no_exchange_difference
-        ).reconcile()
+        )._reconcile_plan([[self.move_line_ids, to_rec_woff_line]])
         for move_line in self.move_line_ids:
             if not move_line.reconciled:
                 raise UserError(

--- a/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual.py
+++ b/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual.py
@@ -265,9 +265,9 @@ class AccountMoveLineReconcileManual(models.TransientModel):
 
     def _get_writeoff_vals_by_simulation(self):
         """
-        In some multi-currency reconciliation case, it is too complicated to 'guess'
-        the needed writeoff amounts. For these case, we do simulate the reconciliation
-        too get the real writeoff amounts
+        In some multi-currency reconciliation cases, it is too complicated to 'guess'
+        the required write-off amounts. For these cases, we simulate the reconciliation
+        to obtain the actual write-off amounts.
         """
         amls = self.move_line_ids
         # From _reconcile_plan_with_sync

--- a/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual_view.xml
+++ b/account_move_line_reconcile_manual/wizards/account_move_line_reconcile_manual_view.xml
@@ -26,6 +26,7 @@
                     <field name="state" invisible="1" />
                     <field name="company_id" invisible="1" />
                     <field name="currency_id" invisible="1" />
+                    <field name="company_currency_id" invisible="1" />
                     <field name="partner_count" invisible="1" />
                     <field name="partner_id" invisible="1" />
                 </group>
@@ -46,7 +47,12 @@
                         options="{'datepicker': {'warn_future': true}}"
                     />
                     <field name="writeoff_ref" />
-                    <field name="writeoff_amount" />
+                    <field name="writeoff_amount" invisible="not writeoff_amount" />
+                    <field
+                        name="writeoff_amount_currency"
+                        invisible="not writeoff_amount_currency or writeoff_currency_id == company_currency_id"
+                    />
+                    <field name="writeoff_currency_id" invisible="1" />
                     <field name="writeoff_type" />
                     <field name="writeoff_account_id" required="state == 'writeoff'" />
                     <field


### PR DESCRIPTION
With this refactore, I think the module is able to manage all the following full reconciliation cases (with writeoff) :
Same currency (foreign or company currency)
Multiple currency (2 currencies, company currency + 1 foreign currency).

Multiple currency cases with more than 1 foreign currencies are not tested and may fail.
But with current implementation, I think it could be managed if really necessary. But maybe it is ok to not manage these kind of weird cases, where the user can still do partial reconciliation, create manual write-off, then complete its reconciliation